### PR TITLE
build(workspace): use Semver postTargets feature

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,17 +33,13 @@ jobs:
                     fetch-depth: 0
             -   uses: ./.github/actions/setup
 
-            -   name: bump version
-                run: yarn nx affected --target=bump-version --base=latest-release --parallel
-                env:
-                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
             -   name: build
                 run: yarn nx affected:build --parallel --production
 
-            -   name: publish to npm
-                run: npx nx affected --target=publish-npm --base=latest-release --parallel
+            -   name: bump version and release it
+                run: npx nx affected --target=release-new-version --base=latest-release --parallel
                 env:
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                     NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLSH_KEY }}
                     NPM_PUBLSH_KEY: ${{ secrets.NPM_PUBLSH_KEY }}
                     NPM_PUBLSH_EMAIL: ${{ secrets.NPM_PUBLSH_EMAIL }}

--- a/packages/config-helper/project.json
+++ b/packages/config-helper/project.json
@@ -29,17 +29,18 @@
 				"passWithNoTests": true
 			}
 		},
-		"bump-version": {
+		"release-new-version": {
 			"executor": "@jscutlery/semver:version",
 			"options": {
-				"versionTagPrefix": "${target}@"
+				"versionTagPrefix": "${target}@",
+				"postTargets": ["${target}:publish-npm"]
 			}
 		},
 		"publish-npm": {
 			"executor": "ngx-deploy-npm:deploy",
 			"options": {
 				"access": "public",
-				"no-build": true
+				"noBuild": true
 			},
 			"dependsOn": [
 				{


### PR DESCRIPTION
We at ngx-deploy-npm discussed fixing something like a problem that you have on #16. We [concluded](https://github.com/bikecoders/ngx-deploy-npm/issues/70#issuecomment-954445035) that it's better to use Semver postTargets feature.

If you want to go deep about what we discussed, you can check the [discussion](https://github.com/bikecoders/ngx-deploy-npm/discussions/73) created to integrate Semver and ngx-deploy-npm.

---

P.S. 
We at ngx-deploy-npm and use that feature.